### PR TITLE
AbstractBundle.prepareContainer() cannot find "plugin.xml" #74

### DIFF
--- a/plugins/org.eclipse.net4j.util/src/org/eclipse/net4j/util/io/IOUtil.java
+++ b/plugins/org.eclipse.net4j.util/src/org/eclipse/net4j/util/io/IOUtil.java
@@ -221,7 +221,8 @@ public final class IOUtil
    */
   public static URL newURL(String url) throws MalformedURLException
   {
-    return URI.create(url).toURL();
+    String escapedUrlString = url.replace(" ", "%20");
+    return URI.create(escapedUrlString).toURL();
   }
 
   /**


### PR DESCRIPTION
A simple escape of spaces to %20 since the deprecated new URL(String) method accepted spaces, but URI.create() does not.