### PR TITLE
EMFUtil.AbsoluteURIPreservingURIHandler should not be a singleton #157

### DIFF
--- a/plugins/org.eclipse.emf.cdo.common/src/org/eclipse/emf/cdo/common/model/EMFUtil.java
+++ b/plugins/org.eclipse.emf.cdo.common/src/org/eclipse/emf/cdo/common/model/EMFUtil.java
@@ -220,8 +220,6 @@ public final class EMFUtil
 
   private static final EPackage.Registry[] GLOBAL_REGISTRY_ARRAY = { EPackage.Registry.INSTANCE };
 
-  private static final XMLResource.URIHandler ABSOLUTE_URI_PRESERVING_URI_HANDLER = new AbsoluteURIPreservingURIHandler();
-
   private static final boolean CONVERT_TO_RELATIVE_URIS = OMPlatform.INSTANCE.isProperty("org.eclipse.emf.cdo.common.model.EMFUtil.CONVERT_TO_RELATIVE_URIS");
 
   private EMFUtil()
@@ -742,7 +740,7 @@ public final class EMFUtil
 
     if (!CONVERT_TO_RELATIVE_URIS)
     {
-      options.put(XMLResource.OPTION_URI_HANDLER, ABSOLUTE_URI_PRESERVING_URI_HANDLER);
+      options.put(XMLResource.OPTION_URI_HANDLER, new AbsoluteURIPreservingURIHandler());
     }
 
     if (zipped)


### PR DESCRIPTION
Changed so that each resource options map has it´s own instance of AbsoluteURIPreservingURIHandler().